### PR TITLE
respect versions in apk package provides

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Usage of renovate-apk-indexer:
 ## Renovate Gitlab example
 
 Renovate gitlab-job (abbreviated):
+
 ```yaml
 renovate:
   services:
@@ -28,18 +29,20 @@ renovate:
 ```
 
 Use it in your renovate.json as a custom datasource:
+
 ```json
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "customDatasources": {
     "wolfi": {
-      "defaultRegistryUrlTemplate": "http://wolfi-apk:3000/wildcardVersion/{{packageName}}"
+      "defaultRegistryUrlTemplate": "http://wolfi-apk:3000/{{packageName}}"
     }
   }
 }
 ```
 
 Usage in code:
+
 ```bash
 # renovate: datasource=custom.wolfi depName=argo-cd
 VERSION=2.13.1-r0
@@ -68,6 +71,7 @@ The server provides an endpoint for `/<PACKAGE_NAME>`, which returns the package
 An additional endpoint is provided at `/wildcardVersion/<PACKAGE_NAME_WITH_WILDCARD_VERSION>`. The wolfi APK index uses an unusual naming scheme where the version is provided within the package name, it is not easily possible for renovate to track version updates for those packages:
 
 E.g. These are all valid package names in the wolfi APK index. Note that the base name without the number does not necessarily contain the most recent version:
+
 ```
 argo-cd
 argo-cd-compat
@@ -94,7 +98,6 @@ To use the wildcard version endpoint, you can provide a single '*' at the point 
 | `/wildcardVersion/argo-cd-*-compat` | will only match `argo-cd-<number>-compat` and argo-cd-compat                                                                                                                                                                                          |
 | `/wildcardVersion/nodejs*`          | will only match `nodejs-<number>`, not `nodejs`.  This is a technical limitation, see explaination of `/wildcardVersion/argo-cd*`                                                                                                                       |
 
-
 ## APK Index updates
 
 By default, the server updates it's packages every 4 hours.
@@ -102,3 +105,4 @@ By default, the server updates it's packages every 4 hours.
 ## Healthchecks
 
 Liveness and Readiness probe endpoints are available at `/livez` and `/readyz`.
+

--- a/main.go
+++ b/main.go
@@ -11,7 +11,6 @@ import (
 	"github.com/gofiber/fiber/v2/middleware/healthcheck"
 	"github.com/hown3d/renovate-apk-indexer/pkg/apk"
 	"github.com/hown3d/renovate-apk-indexer/pkg/renovate"
-	"gitlab.alpinelinux.org/alpine/go/repository"
 )
 
 const wolfiIndex = "https://packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz"
@@ -54,20 +53,6 @@ func main() {
 			return fmt.Errorf("%s not found in wolfi apkIndex", packageName)
 		}
 		datasource := renovate.TransformAPKPackage(packages)
-		return c.JSON(datasource)
-	})
-
-	app.Get("/wildcardVersion/:package", func(c *fiber.Ctx) error {
-		packageName := c.Params("package")
-		matchedPackages := apk.FilterPackagesByWildcard(apkPackages, packageName)
-		var packageList []*repository.Package
-		for _, packages := range matchedPackages {
-			packageList = append(packageList, packages...)
-		}
-		if len(packageList) == 0 {
-			return fmt.Errorf("%s not found in wolfi apkIndex", packageName)
-		}
-		datasource := renovate.TransformAPKPackage(packageList)
 		return c.JSON(datasource)
 	})
 

--- a/pkg/apk/apk.go
+++ b/pkg/apk/apk.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"regexp"
 	"strings"
 
 	"gitlab.alpinelinux.org/alpine/go/repository"
@@ -53,54 +52,16 @@ func parseApkIndex(indexData io.ReadCloser) (map[string][]*repository.Package, e
 func getPackagesMap(packages []*repository.Package) map[string][]*repository.Package {
 	packageMap := make(map[string][]*repository.Package)
 	for _, p := range packages {
-		if packageMap[p.Name] == nil {
-			packageMap[p.Name] = []*repository.Package{p}
-			continue
-		}
 		packageMap[p.Name] = append(packageMap[p.Name], p)
+
+		for _, provide := range p.Provides {
+			if strings.Contains(provide, ":") {
+				continue
+			}
+
+			name, _, _ := strings.Cut(provide, "=")
+			packageMap[name] = append(packageMap[name], p)
+		}
 	}
 	return packageMap
-}
-
-// gets all package names that match the wildcard
-// wildcard is only for versions, which means it won't check for packages with a longer suffix
-// e.g. the wildcard 'argo-cd-*' will match the package "argo-cd-2.12", but not "argo-cd-2.12-repo-server"
-// e.g. the wildcard 'argo-cd-*-repo-server' will match the package "argo-cd-2.12-repo-server"
-func FilterPackagesByWildcard(apkPackages map[string][]*repository.Package, wildcardString string) map[string][]*repository.Package {
-
-	matchedPackages := make(map[string][]*repository.Package)
-
-	// Check if the pattern contains "*"
-	if strings.Contains(wildcardString, "*") {
-		// Extract the prefix before "*"
-		parts := strings.Split(wildcardString, "*")
-		prefix := parts[0]
-		suffix := parts[1]
-
-		// Perform prefix match
-		var isNumberRegex = regexp.MustCompile(`\d+$`)
-		for packageName, apkPackageRepos := range apkPackages {
-			if strings.HasPrefix(packageName, prefix) {
-				if suffix == "" {
-					// Match items that end with a number
-					if match := isNumberRegex.MatchString(packageName); match {
-						fmt.Printf("'%s' Matched package with prefix: %s\n", wildcardString, packageName)
-						matchedPackages[packageName] = apkPackageRepos
-					}
-				} else {
-					// Match items that end with the inferred suffix
-					if strings.HasSuffix(packageName, suffix) {
-						fmt.Printf("'%s' Matched package with suffix: %s\n", wildcardString, packageName)
-						matchedPackages[packageName] = apkPackageRepos
-					}
-				}
-			}
-		}
-		return matchedPackages
-	} else {
-		fmt.Printf("No wildcard detected. Trying '%s' as a direct package-name match\n", wildcardString)
-		matchedPackages[wildcardString] = apkPackages[wildcardString]
-	}
-	fmt.Printf("wildcardString '%s' did not match packages '*'\n", wildcardString)
-	return matchedPackages
 }


### PR DESCRIPTION
Alpine and Wolfi packages have a field `provides`. This field is used by apk do search for packages that don't match the exact package name but still provide a package for the requested name.
This PR adds the functionally for renovate to discover versions from these packages as well.

BREAKING:
Remove unstable wildcard version endpoint.